### PR TITLE
Small bug: spatial domain discretization is wrong

### DIFF
--- a/english/simulation_scripts/taylor_green_turbulence.jl
+++ b/english/simulation_scripts/taylor_green_turbulence.jl
@@ -191,9 +191,9 @@ function cross_product!(
 end
 
 function main()
-    x_range = range(0.0, 2*pi, N_POINTS_P_AXIS)
-    y_range = range(0.0, 2*pi, N_POINTS_P_AXIS)
-    z_range = range(0.0, 2*pi, N_POINTS_P_AXIS)
+    x_range = range(0.0, 2*pi, N_POINTS_P_AXIS+1)[1:end-1]
+    y_range = range(0.0, 2*pi, N_POINTS_P_AXIS+1)[1:end-1]
+    z_range = range(0.0, 2*pi, N_POINTS_P_AXIS+1)[1:end-1]
 
     coordinates_x = [x for x in x_range, y in y_range, z in z_range]
     coordinates_y = [y for x in x_range, y in y_range, z in z_range]


### PR DESCRIPTION
This is a small and commont bug when using FFTs. The domain on each axis is (0, 2π). When discretizing it, the code was including both ends! What this means is that actually the domain has a period of 2π * (1 + 1/(N-1)). This introduces noise and aliasing. And the periodic function is discontinuous.

The domain should be divided in `N_POINTS_P_AXIS` segments and the points should correspond to the left point of each segment.

It is difficult to see but this appears to reduce noise in the solution.